### PR TITLE
Delete unused `UnrecognizedModifier` `Error` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,52 +299,6 @@ impl From<u64> for DrmModifier {
     }
 }
 
-/// Wraps some u64 that isn't a DRM modifier we recognize
-///
-/// ```
-/// # use drm_fourcc::{DrmModifier, UnrecognizedModifier};
-/// # use std::convert::TryFrom;
-/// // Get the u64
-/// assert_eq!(UnrecognizedModifier(42).0, 42);
-/// ```
-#[derive(Copy, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct UnrecognizedModifier(pub u64);
-
-impl Debug for UnrecognizedModifier {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "unrecognized(0x{:x})", self.0)
-    }
-}
-
-impl Display for UnrecognizedModifier {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Debug::fmt(&self, f)
-    }
-}
-
-#[cfg(feature = "std")]
-impl Error for UnrecognizedModifier {}
-
-impl UnrecognizedModifier {
-    /// Get the vendor of the unrecognized modifier, if any
-    ///
-    /// ```
-    /// # use drm_fourcc::{DrmModifier, DrmVendor, UnrecognizedModifier, UnrecognizedVendor};
-    /// assert_eq!(UnrecognizedModifier(216172782113783827).vendor(), Ok(Some(DrmVendor::Nvidia)));
-    /// assert_eq!(UnrecognizedModifier(2).vendor(), Ok(None));
-    /// assert_eq!(UnrecognizedModifier(8646911284551352320).vendor(), Err(UnrecognizedVendor(120)));
-    /// ```
-    pub fn vendor(&self) -> Result<Option<DrmVendor>, UnrecognizedVendor> {
-        let vendor = (self.0 >> 56) as u8;
-        if vendor == 0 {
-            Ok(None)
-        } else {
-            DrmVendor::try_from(vendor).map(Some)
-        }
-    }
-}
-
 impl From<DrmModifier> for u64 {
     /// Convert to an u64
     ///


### PR DESCRIPTION
As found in https://github.com/dzfranklin/drm-fourcc-rs/issues/17#issuecomment-1319084498 this type is unused because no `TryFrom` is implemented for `DrmModifier`, which instead allows all unknown modifiers via an `::Unknown(u64)` variant.

In addition we likely want to replace the other errors for `DrmFourcc` and `DrmVendor` with a regular `From<>` and `::Unknown()` as well, because new enums are added somewhat regularly (at least more frequent than crate releases) and are generally easier to pass through systems, even if that no longer makes them a proper `repr` and gives faulty values for `drm_xxx as uXX`.
Note however this drawback: https://github.com/dzfranklin/drm-fourcc-rs/pull/28#issuecomment-3166031755